### PR TITLE
Support SonarRanges in lieu of SonarDetections

### DIFF
--- a/include/acoustic_msgs_tools/water_column_view.h
+++ b/include/acoustic_msgs_tools/water_column_view.h
@@ -6,10 +6,13 @@
 #include <rclcpp/node.hpp>
 #include <marine_acoustic_msgs/msg/raw_sonar_image.hpp>
 #include <marine_acoustic_msgs/msg/sonar_detections.hpp>
+#include <marine_acoustic_msgs/msg/sonar_ranges.hpp>
 #include <qtimer.h>
 #include "libInterpolate/Interpolate.hpp"
 #include "rclcpp/executors.hpp"
-//#include "ros/master.h"
+
+#include <map>
+#include <string>
 
 namespace Ui {
 class WaterColumnView;
@@ -26,6 +29,7 @@ public:
 
   void wcCallback(const marine_acoustic_msgs::msg::RawSonarImage::SharedPtr wc_msg);
   void detectionCallback(const marine_acoustic_msgs::msg::SonarDetections::SharedPtr det_msg);
+  void rangesCallback(const marine_acoustic_msgs::msg::SonarRanges::SharedPtr rng_msg);
 private slots:
   void spinOnce();
   void updateRangeBearing(QMouseEvent *event);
@@ -52,10 +56,12 @@ private:
   rclcpp::Node::SharedPtr node_;
   rclcpp::Subscription<marine_acoustic_msgs::msg::RawSonarImage>::SharedPtr wc_sub_;
   rclcpp::Subscription<marine_acoustic_msgs::msg::SonarDetections>::SharedPtr det_sub_;
+  rclcpp::Subscription<marine_acoustic_msgs::msg::SonarRanges>::SharedPtr rng_sub_;
   QTimer *ros_timer;
   QCPColorMap *colorMap;
   QCPGraph *detctionGraph;
   bool new_msg;
+  std::map<std::string, std::string> topic_to_type;
 };
 
 #endif // WATER_COLUMN_VIEW_H

--- a/src/water_column_view.cpp
+++ b/src/water_column_view.cpp
@@ -222,6 +222,26 @@ void WaterColumnView::detectionCallback(const marine_acoustic_msgs::msg::SonarDe
   ui->plot->replot();
 }
 
+void WaterColumnView::rangesCallback(const marine_acoustic_msgs::msg::SonarRanges::SharedPtr rng_msg){
+  auto n = rng_msg->ranges.size();
+  checkFlipState();
+  QVector<double> x(n), y(n);
+  for(size_t i=0; i<n; i++){
+    double range = rng_msg->ranges[i];
+    double rx_angle = rng_msg->beam_unit_vec[i].x; // TODO: Validate it's changing along the x axis
+    x[i] = range * sin(rx_angle);
+    y[i] = range * cos(rx_angle);
+  }
+  detctionGraph->setData(x, y);
+  QPen pen;
+  pen.setColor(QColor(QColorConstants::Green));
+  ui->plot->graph()->setPen(pen);
+  ui->plot->graph()->setLineStyle((QCPGraph::LineStyle::lsNone));
+  ui->plot->graph()->setScatterStyle(QCPScatterStyle(QCPScatterStyle::ssPlus, 4));
+
+  ui->plot->replot();
+}
+
 
 void WaterColumnView::spinOnce(){
   if(rclcpp::ok()){
@@ -293,9 +313,11 @@ void WaterColumnView::updateTopics(){
   QStringList topic_list;
     for(auto topic : master_topics){
       QString::fromStdString("topic[0]");
-      if(topic.second[0]=="marine_acoustic_msgs/msg/SonarDetections"){
+      if(topic.second[0]=="marine_acoustic_msgs/msg/SonarDetections" ||
+         topic.second[0]=="marine_acoustic_msgs/msg/SonarRanges"){
         QString::fromStdString(topic.first);
         topic_list.push_back(QString::fromStdString(topic.first));
+        topic_to_type[topic.first] = topic.second[0];
       }
     }
     ui->detect_topic->addItems(topic_list);
@@ -325,14 +347,32 @@ void WaterColumnView::on_auto_gain_stateChanged(int state)
 
 void WaterColumnView::on_detect_topic_currentTextChanged(const QString &arg1)
 {
-  if(arg1.toStdString()==""){
+  std::string topic = arg1.toStdString();
+  if(topic==""){
     return;
   }
-  if(!det_sub_ || det_sub_->get_topic_name() != arg1.toStdString()){
+  if(!det_sub_ || det_sub_->get_topic_name() != topic){
     using std::placeholders::_1;
-    det_sub_ = node_->create_subscription<marine_acoustic_msgs::msg::SonarDetections>(
-          arg1.toStdString(), 1, std::bind(&WaterColumnView::detectionCallback, this, _1));;
-    new_msg = true;
+
+    auto const tt = topic_to_type.find(topic);
+
+    if(tt == topic_to_type.end())
+        return;
+
+    if(tt->second == "marine_acoustic_msgs/msg/SonarDetections")
+    {
+      rng_sub_.reset();
+      det_sub_ = node_->create_subscription<marine_acoustic_msgs::msg::SonarDetections>(
+        topic, 1, std::bind(&WaterColumnView::detectionCallback, this, _1));
+      new_msg = true;
+    }
+    else if (tt->second == "marine_acoustic_msgs/msg/SonarRanges")
+    {
+      det_sub_.reset();
+      rng_sub_ = node_->create_subscription<marine_acoustic_msgs::msg::SonarRanges>(
+        topic, 1, std::bind(&WaterColumnView::rangesCallback, this, _1));
+      new_msg = true;
+    }
   }
 }
 

--- a/src/water_column_view.cpp
+++ b/src/water_column_view.cpp
@@ -3,8 +3,8 @@
 
 WaterColumnView::WaterColumnView(QWidget *parent) :
   QWidget(parent),
-  ui(new Ui::WaterColumnView),
-  Node("water_column_view")
+  Node("water_column_view"),
+  ui(new Ui::WaterColumnView)
 {
   ui->setupUi(this);
 
@@ -137,10 +137,6 @@ void WaterColumnView::checkFlipState(){
 void WaterColumnView::wcCallback(const marine_acoustic_msgs::msg::RawSonarImage::SharedPtr wc_msg){
   auto M = wc_msg->samples_per_beam;
   auto N = wc_msg->rx_angles.size();
-
-
-
-  const uint8_t *bits = wc_msg->image.data.data();
 
   auto beam_angles = wc_msg->rx_angles;
   std::vector<float> beam_index;


### PR DESCRIPTION
Creating a node for the SonarPhony fishfinder, but that doesn't provide SonarDetections, really just ranges. Tweaks to allow either to be rendered.

![Screenshot from 2025-04-14 21-23-27](https://github.com/user-attachments/assets/69f0d8ce-ae87-478e-bbe8-7e0da6be7dd8)

Only slightly related, but this did also bring up an interesting challenge, because there's no way to represent the min/max range of a SonarImage, you have to use sound speed and sample rate...

`range = total_samples * sound_speed / sample_rate`

So I know `range` and `total_samples`, but not `sound_speed` or `sample_rate`. I faked it in the above image by just setting sound_speed to 1500, but that's not a real solution.